### PR TITLE
Updated src files to work with node.js

### DIFF
--- a/src/node/DataRetrieval.js
+++ b/src/node/DataRetrieval.js
@@ -1,0 +1,197 @@
+const axios = require("axios");
+
+class DataRetrieval {
+  constructor(restURL) {
+    this.restURL = restURL;
+  }
+
+  async balancesForAddress(address) {
+    try {
+      let response = await axios.get(
+        `${this.restURL}dataRetrieval/balancesForAddress/${address}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async balancesForId(propertyId) {
+    try {
+      let response = await axios.get(
+        `${this.restURL}dataRetrieval/balancesForId/${propertyId}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async balance(address, propertyId) {
+    try {
+      let response = await axios.get(
+        `${this.restURL}dataRetrieval/balance/${address}/${propertyId}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async balancesHash(propertyId) {
+    try {
+      let response = await axios.get(
+        `${this.restURL}dataRetrieval/balancesHash/${propertyId}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async crowdSale(propertyId) {
+    try {
+      let response = await axios.get(
+        `${this.restURL}dataRetrieval/crowdSale/${propertyId}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async currentConsensusHash() {
+    try {
+      let response = await axios.get(
+        `${this.restURL}dataRetrieval/currentConsensusHash`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async grants(propertyId) {
+    try {
+      let response = await axios.get(
+        `${this.restURL}dataRetrieval/grants/${propertyId}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async info() {
+    try {
+      let response = await axios.get(`${this.restURL}dataRetrieval/info`);
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async payload(txid) {
+    try {
+      let response = await axios.get(
+        `${this.restURL}dataRetrieval/payload/${txid}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async property(propertyId) {
+    try {
+      let response = await axios.get(
+        `${this.restURL}dataRetrieval/property/${propertyId}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async seedBlocks(startBlock, endBlock) {
+    try {
+      let response = await axios.get(
+        `${this.restURL}dataRetrieval/seedBlocks/${startBlock}/${endBlock}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async STO(txid, recipientFilter) {
+    try {
+      let response = await axios.get(
+        `${this.restURL}dataRetrieval/STO/${txid}/${recipientFilter}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async transaction(txid) {
+    try {
+      let response = await axios.get(
+        `${this.restURL}dataRetrieval/transaction/${txid}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async blockTransactions(index) {
+    try {
+      let response = await axios.get(
+        `${this.restURL}dataRetrieval/blockTransactions/${index}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async pendingTransactions(address) {
+    let path = `${this.restURL}dataRetrieval/pendingTransactions`;
+    if (address) {
+      path = `${
+        this.restURL
+      }dataRetrieval/pendingTransactions?address=${address}`;
+    }
+    try {
+      let response = await axios.get(path);
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async properties() {
+    try {
+      let response = await axios.get(`${this.restURL}dataRetrieval/properties`);
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async transactions() {
+    try {
+      let response = await axios.get(
+        `${this.restURL}dataRetrieval/transactions`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+}
+
+//export default DataRetrieval;
+module.exports = DataRetrieval;

--- a/src/node/PayloadCreation.js
+++ b/src/node/PayloadCreation.js
@@ -1,0 +1,192 @@
+const axios = require("axios");
+
+class PayloadCreation {
+  constructor(restURL) {
+    this.restURL = restURL;
+  }
+
+  async burnBCH() {
+    try {
+      let response = await axios.get(`${this.restURL}payloadCreation/burnBCH`);
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async changeIssuer(propertyId) {
+    try {
+      let response = await axios.post(
+        `${this.restURL}payloadCreation/changeIssuer/${propertyId}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async closeCrowdSale(propertyId) {
+    try {
+      let response = await axios.post(
+        `${this.restURL}payloadCreation/closeCrowdSale/${propertyId}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async grant(propertyId, amount, memo = "") {
+    let path;
+    if (memo !== "") {
+      path = `${
+        this.restURL
+      }payloadCreation/grant/${propertyId}/${amount}?memo=${memo}`;
+    } else {
+      path = `${this.restURL}payloadCreation/grant/${propertyId}/${amount}`;
+    }
+    try {
+      let response = await axios.post(path);
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async crowdsale(
+    ecosystem,
+    propertyPrecision,
+    previousId,
+    category,
+    subcategory,
+    name,
+    url,
+    data,
+    propertyIdDesired,
+    tokensPerUnit,
+    deadline,
+    earlyBonus,
+    undefine,
+    totalNumber
+  ) {
+    try {
+      let response = await axios.post(
+        `${
+          this.restURL
+        }payloadCreation/crowdsale/${ecosystem}/${propertyPrecision}/${previousId}/${category}/${subcategory}/${name}/${url}/${data}/${propertyIdDesired}/${tokensPerUnit}/${deadline}/${earlyBonus}/${undefine}/${totalNumber}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async fixed(
+    ecosystem,
+    propertyPrecision,
+    previousId,
+    category,
+    subcategory,
+    name,
+    url,
+    data,
+    amount
+  ) {
+    try {
+      let response = await axios.post(
+        `${
+          this.restURL
+        }payloadCreation/fixed/${ecosystem}/${propertyPrecision}/${previousId}/${category}/${subcategory}/${name}/${url}/${data}/${amount}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async managed(
+    ecosystem,
+    propertyPrecision,
+    previousId,
+    category,
+    subcategory,
+    name,
+    url,
+    data
+  ) {
+    try {
+      let response = await axios.post(
+        `${
+          this.restURL
+        }payloadCreation/managed/${ecosystem}/${propertyPrecision}/${previousId}/${category}/${subcategory}/${name}/${url}/${data}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async participateCrowdSale(amount) {
+    try {
+      let response = await axios.post(
+        `${this.restURL}payloadCreation/participateCrowdSale/${amount}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async revoke(propertyId, amount) {
+    try {
+      let response = await axios.post(
+        `${this.restURL}payloadCreation/revoke/${propertyId}/${amount}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async sendAll(ecosystem) {
+    try {
+      let response = await axios.post(
+        `${this.restURL}payloadCreation/sendAll/${ecosystem}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async simpleSend(propertyId, amount) {
+    try {
+      let response = await axios.post(
+        `${this.restURL}payloadCreation/simpleSend/${propertyId}/${amount}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async STO(propertyId, amount, distributionProperty = undefined) {
+    let path;
+    if (distributionProperty !== undefined) {
+      path = `${
+        this.restURL
+      }payloadCreation/STO/${propertyId}/${amount}?distributionProperty=${distributionProperty}`;
+    } else {
+      path = `${this.restURL}payloadCreation/STO/${propertyId}/${amount}`;
+    }
+    try {
+      let response = await axios.post(path);
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+}
+
+//export default PayloadCreation;
+module.exports = PayloadCreation;

--- a/src/node/RawTransactions.js
+++ b/src/node/RawTransactions.js
@@ -1,0 +1,114 @@
+const axios = require("axios");
+
+class RawTransactions {
+  constructor(restURL, rawTransactions) {
+    this.restURL = restURL;
+    this.decodeRawTransaction = rawTransactions.decodeRawTransaction;
+    this.decodeScript = rawTransactions.decodeScript;
+    this.getRawTransaction = rawTransactions.getRawTransaction;
+    this.sendRawTransaction = rawTransactions.sendRawTransaction;
+  }
+
+  async change(rawtx, prevTxs, destination, fee, position = undefined) {
+    let path;
+    if (position) {
+      path = `${this.restURL}rawTransactions/change/${rawtx}/${JSON.stringify(
+        prevTxs
+      )}/${destination}/${fee}?position=${position}`;
+    } else {
+      path = `${this.restURL}rawTransactions/change/${rawtx}/${JSON.stringify(
+        prevTxs
+      )}/${destination}/${fee}`;
+    }
+    try {
+      let response = await axios.post(path);
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async input(rawtx, txid, n) {
+    try {
+      let response = await axios.post(
+        `${this.restURL}rawTransactions/input/${rawtx}/${txid}/${n}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async opReturn(rawtx, payload) {
+    try {
+      let response = await axios.post(
+        `${this.restURL}rawTransactions/opReturn/${rawtx}/${payload}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async reference(rawtx, destination, amount) {
+    let path;
+    if (amount) {
+      path = `${
+        this.restURL
+      }rawTransactions/reference/${rawtx}/${destination}?amount=${amount}`;
+    } else {
+      path = `${this.restURL}rawTransactions/reference/${rawtx}/${destination}`;
+    }
+    try {
+      let response = await axios.post(path);
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async decodeTransaction(rawtx, prevTxs = undefined, height = undefined) {
+    let path;
+    if (prevTxs) {
+      path = `${
+        this.restURL
+      }rawTransactions/decodeTransaction/${rawtx}?prevTxs=${JSON.stringify(
+        prevTxs
+      )}`;
+    } else if (prevTxs && height) {
+      path = `${
+        this.restURL
+      }rawTransactions/decodeTransaction/${rawtx}?prevTxs=${JSON.stringify(
+        prevTxs
+      )}&height=${height}`;
+    } else if (height) {
+      path = `${
+        this.restURL
+      }rawTransactions/decodeTransaction/${rawtx}?height=${height}`;
+    } else {
+      path = `${this.restURL}rawTransactions/decodeTransaction/${rawtx}`;
+    }
+    try {
+      let response = await axios.get(path);
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+
+  async create(inputs, outputs = {}) {
+    try {
+      let response = await axios.post(
+        `${this.restURL}rawTransactions/create/${JSON.stringify(
+          inputs
+        )}/${JSON.stringify(outputs)}`
+      );
+      return response.data;
+    } catch (error) {
+      throw error.response.data;
+    }
+  }
+}
+
+//export default RawTransactions;
+module.exports = RawTransactions;

--- a/src/node/Wormhole.js
+++ b/src/node/Wormhole.js
@@ -1,0 +1,24 @@
+let BITBOXCli = require("bitbox-cli/lib/bitbox-cli").default;
+const DataRetrieval = require("./DataRetrieval");
+const PayloadCreation = require("./PayloadCreation");
+const RawTransactions = require("./RawTransactions");
+
+class Wormhole extends BITBOXCli {
+  constructor(config) {
+    super(config);
+    if (config && config.restURL && config.restURL !== "") {
+      this.restURL = config.restURL;
+    } else {
+      this.restURL = "https://wormholerest.bitcoin.com/v1/";
+    }
+
+    this.DataRetrieval = new DataRetrieval(this.restURL);
+    this.PayloadCreation = new PayloadCreation(this.restURL);
+    this.RawTransactions = new RawTransactions(
+      this.restURL,
+      this.RawTransactions
+    );
+  }
+}
+
+module.exports = Wormhole;


### PR DESCRIPTION
This PR addresses the issues described in Issue #7. 

Something is breaking in the babbelification of the files in the `src` directory. This PR creates a subdirectory `node` which manually converted the files in `src` to work with node.js v8 LTS. The changes have been tested and work when a node.js app includes `src/node/Wormhole.js` directly. 

It may not be desirable to merge the code in this PR directly, as babbeling the code to a common library is probably desirable. The code in this PR does not attempt to be compatible with any other JavaScript implementation than nodejs v8 LTS. The purpose of this PR is simply to show off one way of making the original code work with nodejs. 