### PR TITLE
Fixing output display of WH token info

### DIFF
--- a/examples/check-balance/check-balance.js
+++ b/examples/check-balance/check-balance.js
@@ -9,7 +9,7 @@ const BITBOXCli = require("bitbox-cli/lib/bitbox-cli").default;
 const BITBOX = new BITBOXCli({ restURL: "https://trest.bitcoin.com/v1/" });
 const WH = require("wormholecash/lib/Wormhole").default;
 const Wormhole = new WH({
-  restURL: `https://wormholecash-staging.herokuapp.com/v1/`
+  restURL: `https://wormholecash-staging.herokuapp.com/v1/`,
 });
 
 // Open the wallet generated with create-wallet.
@@ -17,22 +17,24 @@ let walletInfo;
 try {
   walletInfo = require(`../create-wallet/wallet.json`);
 } catch (err) {
-  console.log(
-    `Could not open wallet.json. Generate a wallet with create-wallet first.`
-  );
+  console.log(`Could not open wallet.json. Generate a wallet with create-wallet first.`);
   process.exit(0);
 }
 
 async function getBalance() {
   try {
     // first get BCH balance
-    let balance = await BITBOX.Address.details([walletInfo.cashAddress]);
+    const balance = await BITBOX.Address.details([walletInfo.cashAddress]);
+
+    console.log(`BCH Balance information:`);
+    console.log(balance);
 
     // get token balances
-    balance[0].tokens = await Wormhole.DataRetrieval.balancesForAddress(
-      walletInfo.cashAddress
-    );
-    console.log(balance);
+    const tokens = await Wormhole.DataRetrieval.balancesForAddress(walletInfo.cashAddress);
+
+    console.log(``);
+    console.log(`Wormhole Token information:`);
+    console.log(JSON.stringify(tokens, null, 2));
   } catch (err) {
     console.error(`Error in getBalance: `, err);
     throw err;


### PR DESCRIPTION
The check-balance example is displaying [Object] for tokens:
```
       '03362177597b184c725b18b92ee3119b062032a3b53614e7324c7971c10f733c',
       'bf4c8f36770d7de2ecaebdf58ea4b64700cbacaff7e6228362a9ae1c8d757c08' ],
    legacyAddress: 'mhQ4BtyJqFqtjRJAPHbDVVKc8bF63usAt6',
    cashAddress: 'bchtest:qq22ys5qz8z4jzkkex7p5jrdd9vh6q06cgrpsx2fu7',
    tokens: [ [Object], [Object], [Object] ] } ]
trout@trout-fitlet2 ~/work/bch/wormholecash/examples/check-balance $ npm start
```

This PR fixes the `tokens` output to display token information.