### PR TITLE
Fixes First Three Examples

### DIFF
--- a/examples/check-balance/check-balance.js
+++ b/examples/check-balance/check-balance.js
@@ -3,11 +3,9 @@
   create-wallet example app.
 */
 
-"use strict"
-
 const WH = require("wormholecash/lib/Wormhole").default
-//const Wormhole = new WH({restURL: `https://wormholecash-staging.herokuapp.com/v1/`})
-const Wormhole = new WH({ restURL: `http://localhost:3000/v1/` })
+//const Wormhole = new WH({ restURL: `https://trest.bitcoin.com/v1/` })
+const Wormhole = new WH({ restURL: `https://trest.christroutner.com/v1/` })
 
 // Open the wallet generated with create-wallet.
 let walletInfo

--- a/examples/create-wallet/create-wallet.js
+++ b/examples/create-wallet/create-wallet.js
@@ -3,11 +3,9 @@
   will be used in future examples.
 */
 
-"use strict"
-
 const WH = require("wormholecash/lib/Wormhole").default
-//const Wormhole = new WH({restURL: `https://wormholecash-staging.herokuapp.com/v1/`})
-const Wormhole = new WH({ restURL: `http://localhost:3000/v1/` })
+//const Wormhole = new WH({ restURL: `https://trest.bitcoin.com/v1/` })
+const Wormhole = new WH({ restURL: `https://trest.christroutner.com/v1/` })
 
 const fs = require("fs")
 


### PR DESCRIPTION
This PR fixes the first three examples that let a user create a wallet, check their balance, and send BCH. The examples are setup to use trest.christroutner.com with trest.bitcoin.com commented out and ready to switch over once it starts working.